### PR TITLE
Don't assume nakadi offsets are numbers

### DIFF
--- a/src/main/scala/org/zalando/znap/source/nakadi/XNakadiCursors.scala
+++ b/src/main/scala/org/zalando/znap/source/nakadi/XNakadiCursors.scala
@@ -16,7 +16,7 @@ import scala.util.Try
   */
 class XNakadiCursors(partition: String, offset: String) extends CustomHeader {
   require(Try(partition.toInt).isSuccess)
-  require(offset == "BEGIN" || (offset != null && offset.length > 0))
+  require(offset != null && offset.length > 0)
 
   override def name(): String = "X-Nakadi-Cursors"
 

--- a/src/main/scala/org/zalando/znap/source/nakadi/XNakadiCursors.scala
+++ b/src/main/scala/org/zalando/znap/source/nakadi/XNakadiCursors.scala
@@ -15,8 +15,8 @@ import scala.util.Try
   * HTTP header for Nakadi cursor.
   */
 class XNakadiCursors(partition: String, offset: String) extends CustomHeader {
-  assert(Try(partition.toInt).isSuccess)
-  assert(offset == "BEGIN" || Try(offset.toLong).isSuccess)
+  require(Try(partition.toInt).isSuccess)
+  require(offset == "BEGIN" || (offset != null && offset.length > 0))
 
   override def name(): String = "X-Nakadi-Cursors"
 


### PR DESCRIPTION
The assumption is now, while we have no concrete information yet, is that a non-null and non-empty string is a valid offset. 
"require" won't disappear if assertions are disabled.