### PR TITLE
Use akka-http 10.0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-stream" % akkaVersion,
 //    "com.typesafe.akka" %% "akka-http-core" % akkaVersion,
 //    "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion,
-    "com.typesafe.akka" %% "akka-http" % "10.0.3",
+    "com.typesafe.akka" %% "akka-http" % "10.0.4",
     "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
 
     "ch.qos.logback" % "logback-classic" % "1.1.7",


### PR DESCRIPTION
- fixes memory leak introduced in akka-http 10.0.3
- see http://akka.io/news/2017/02/23/akka-http-10.0.4-released.html for details